### PR TITLE
Allow throwing destructors to throw in C++11

### DIFF
--- a/src/common/nmv-api-macros.h
+++ b/src/common/nmv-api-macros.h
@@ -52,5 +52,12 @@
 #  define NEMIVER_PURE_IFACE
 #  define NEMIVER_API
 # endif //HAS_GCC_VISIBILITY_SUPPORT
+
+# if __cplusplus >= 201103L
+#  define DTOR_NOEXCEPT noexcept(false)
+# else
+#  define DTOR_NOEXCEPT
+# endif //__cplusplus >= 201103L
+
 #endif
 

--- a/src/common/nmv-log-stream.cc
+++ b/src/common/nmv-log-stream.cc
@@ -373,7 +373,7 @@ LogStream::LogStream (enum LogLevel a_level,
     }
 }
 
-LogStream::~LogStream ()
+LogStream::~LogStream () DTOR_NOEXCEPT
 {
     LOG_D ("delete", "destructor-domain");
     ABORT_IF_FAIL2 (m_priv, "double free in LogStream::~LogStream");

--- a/src/common/nmv-log-stream.h
+++ b/src/common/nmv-log-stream.h
@@ -151,7 +151,7 @@ public:
                const string &a_default_domain=NMV_GENERAL_DOMAIN);
 
     /// \brief destructor of the log stream class
-    virtual ~LogStream ();
+    virtual ~LogStream () DTOR_NOEXCEPT;
 
     /// \brief enable or disable logging for a domain
     /// \param a_domain the domain to enable logging for

--- a/src/common/nmv-object.cc
+++ b/src/common/nmv-object.cc
@@ -68,7 +68,7 @@ Object::operator= (Object const &a_object)
     return *this;
 }
 
-Object::~Object ()
+Object::~Object () DTOR_NOEXCEPT
 {
 }
 

--- a/src/common/nmv-object.h
+++ b/src/common/nmv-object.h
@@ -54,7 +54,7 @@ public:
 
     Object& operator= (Object const&);
 
-    virtual ~Object ();
+    virtual ~Object () DTOR_NOEXCEPT;
 
     void ref ();
 

--- a/src/common/nmv-transaction.h
+++ b/src/common/nmv-transaction.h
@@ -116,7 +116,7 @@ struct TransactionAutoHelper
         return m_trans;
     }
 
-    ~TransactionAutoHelper ()
+    ~TransactionAutoHelper () DTOR_NOEXCEPT
     {
         if (m_ignore) {
             return;


### PR DESCRIPTION
In C++11/14, destructors default to `noexcept(true)`.  As a consequence, all throw statements in such destructors become calls to `std::terminate()`.  When built with GCC-6 and with `-Werror=terminate` in CXXFLAGS, the build fails with:

> error: throw will always call terminate()

To enable the intended pre-C++11 throwing behavior, such destructors need to be explicitly marked `noexcept(false)`.

Note that though `Object::~Object` in `nmv-object.cc` doesn't throw, it is the most base virtual destructor in a class hierarchy with some inheriting destructors which do throw (such as `nemiver::common::LogStream::~LogStream()` in `src/common/nmv-log-stream.cc`), and such inheriting destructors are not allowed less strict exception specification than more base destructors.  Also, because exception specification is part of the inherited interface, it suffices just to mark the most base virtual destructor `noexcept(false)`.
